### PR TITLE
Rewrite Anthropic adapter for Opus 4.6-4.8, Sonnet 4.6/5, Fable 5/Myt…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,34 +112,55 @@ To add support for a new AI vendor:
 **Unified Thinking/Reasoning:**
 Use `isThinkingCapable` flag, `budgetTokens` parameter, and `ThinkingBlock` type to handle both Anthropic's extended thinking and OpenRouter's reasoning features consistently.
 
-**Claude 4.6+ Support:**
-The Anthropic adapter automatically detects model versions and uses the appropriate API format:
+**Claude Model Support (3.x through Opus 4.8 / Sonnet 5 / Fable 5 / Mythos 5):**
+The Anthropic adapter (`src/vendors/anthropic.ts`) classifies each request's model into two
+*independent* tiers, rather than a single generation string, because Anthropic's thinking API
+and its sampling-parameter constraints don't change in lockstep across releases:
 
-- **Claude 4.6+ Models** (`claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`):
-  - Uses adaptive thinking: `thinking: {type: "adaptive"}`
-  - Maps `budgetTokens` to `effort` parameter (low: 0-1, medium: 1-8192, high: 8192+)
-  - Supports explicit `effort` parameter in `AIRequestOptions` (overrides budgetTokens mapping)
-  - Supports `outputFormat` for structured outputs via `output_config.format`
-  - Cannot use both `temperature` and `topP` (will throw error)
-  - Handles new stop reasons: `refusal`, `model_context_window_exceeded`
+- `getThinkingTier(model)` → `"legacyBudget" | "adaptiveTransitional" | "adaptiveOnly"` — controls
+  whether thinking uses `budget_tokens` or `{type: "adaptive"}`, and which `effort` levels are valid.
+- `getSamplingPolicy(model)` → `"both" | "single" | "none"` — controls how many of
+  `temperature`/`topP` may be sent. This does **not** track the thinking tier 1:1: e.g. Sonnet 4.5
+  and Haiku 4.5 use legacy `budget_tokens` thinking, but like every Claude 4+ model they still
+  reject sending both sampling params together.
 
-- **Legacy Models** (Claude 3.x, 4.0-4.5):
-  - Uses `thinking: {type: "enabled", budget_tokens: N}`
-  - Claude 3.x models support both temperature and topP simultaneously
-  - Claude 4.0-4.5 models only support temperature OR topP (not both)
+| Thinking tier | Models | Thinking request shape | Effort levels |
+|---|---|---|---|
+| `legacyBudget` (default/fallback) | Claude 3.x, Opus 4.0/4.1/4.5, Sonnet 4.0/4.5, Haiku 3.x/4.5, any unrecognized model | `thinking: {type: "enabled", budget_tokens: N}` | none — no `output_config` |
+| `adaptiveTransitional` | `claude-opus-4-6`, `claude-sonnet-4-6` | `thinking: {type: "adaptive"}` | low / medium / high / max |
+| `adaptiveOnly` | `claude-opus-4-7`, `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-mythos-5` | `thinking: {type: "adaptive"}` only — `budget_tokens` is never sent | low / medium / high / xhigh / max |
+
+| Sampling policy | Models | Behavior |
+|---|---|---|
+| `both` | Claude 2.x / 3.x only | `temperature` and `topP` may both be sent |
+| `single` | Everything 4.x that isn't `adaptiveOnly` (4.0-4.5, the 4.6 family, Sonnet 4.5, Haiku 4.5, etc.) | At most one of `temperature`/`topP` — throws if both are set |
+| `none` | `adaptiveOnly` tier (Opus 4.7/4.8, Sonnet 5, Fable 5, Mythos 5) | Throws if *either* `temperature` or `topP` is set at all |
+
+Other tier-driven behavior:
+- `effort` (`"low" | "medium" | "high" | "xhigh" | "max"`) is honored on both adaptive tiers; when
+  omitted, `budgetTokens` is mapped via a simple heuristic (`mapBudgetToEffort`) that only reaches
+  low/medium/high — `xhigh`/`max` require an explicit `effort` value.
+- `outputFormat` (structured outputs via `output_config.format`) is supported on both adaptive
+  tiers, not just `adaptiveOnly`.
+- Stop reason `refusal` includes `stop_details.category` (e.g. `"cyber"`, `"bio"`) in the
+  `ErrorBlock.privateMessage` when the SDK response provides it. `model_context_window_exceeded`
+  is also handled.
+- `sendChat()` forwards `effort`, `temperature`, `topP`, and `outputFormat` from `Chat` to
+  `generateResponse()` (all optional fields on `Chat` — omitting them preserves prior behavior for
+  existing callers). `thinkingMode` is derived as `(chat.budgetTokens ?? 0) > 0 || !!chat.effort`.
 
 Example:
 ```typescript
-// Claude 4.6 with adaptive thinking
+// Opus 4.8 (adaptiveOnly) — adaptive thinking, no sampling params allowed
 const response = await adapter.generateResponse({
-  model: 'claude-opus-4-6',
+  model: 'claude-opus-4-8',
   messages: [...],
   thinkingMode: true,
-  effort: 'high',  // or use budgetTokens for automatic mapping
+  effort: 'xhigh',  // or omit and use budgetTokens for automatic low/medium/high mapping
   maxTokens: 4096,
 });
 
-// Claude 3.x with legacy thinking
+// Claude 3.x (legacyBudget) — classic thinking, both sampling params allowed
 const response = await adapter.generateResponse({
   model: 'claude-3-opus-20240229',
   messages: [...],

--- a/README.md
+++ b/README.md
@@ -295,6 +295,47 @@ interface ChatResponse {
 2.  Iterate through the `content` array to process and display the different blocks appropriately (e.g., render text, display images, trigger tool execution).
 3.  **For conversations, add the entire response object to your `responseHistory`** so the AI has context for the next turn.
 
+## Anthropic Models: Thinking, Effort, and Sampling Parameters
+
+Snowgander stays a thin wrapper: to use a new Claude model (Opus 4.6/4.7/4.8, Sonnet 4.6/5, Fable 5, Mythos 5), just set `apiName` to the model string in your `ModelConfig` — no code changes to `generateResponse`, `streamResponse`, or `sendChat` are required. The Anthropic adapter detects the right request shape automatically based on the model string.
+
+**⚠️ One behavior change to be aware of when adopting the newest models:** `claude-opus-4-7`, `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, and `claude-mythos-5` reject `temperature`/`topP` entirely — the adapter throws if **either** is set, not just both together. If your existing code always sets a default `temperature`, remove it (or branch on model) before pointing that same call at one of these models, or `generateResponse`/`sendChat` will throw instead of silently ignoring it.
+
+| Models | `temperature` / `topP` | `thinkingMode` behavior | `effort` levels |
+| --- | --- | --- | --- |
+| Claude 3.x | Both allowed together | `budgetTokens` → `budget_tokens` | n/a |
+| Opus 4.0–4.5, Sonnet 4.0/4.5, Haiku 3.x/4.5 | At most one | `budgetTokens` → `budget_tokens` | n/a |
+| Opus 4.6, Sonnet 4.6 | At most one | Adaptive thinking | `low` / `medium` / `high` / `max` |
+| Opus 4.7/4.8, Sonnet 5, Fable 5, Mythos 5 | **Neither allowed** | Adaptive thinking only | `low` / `medium` / `high` / `xhigh` / `max` |
+
+For models that support adaptive thinking, `budgetTokens` is still accepted for backward compatibility and is automatically mapped to a reasonable `effort` level — or pass `effort` explicitly for direct control (including the newer `"xhigh"`/`"max"` levels):
+
+```typescript
+const options: AIRequestOptions = {
+  model: "claude-opus-4-8",
+  messages: [{ role: "user", content: [{ type: "text", text: "Solve this." }] }],
+  thinkingMode: true,
+  effort: "xhigh", // low | medium | high | xhigh | max
+  maxTokens: 4096,
+  // Do NOT set temperature/topP here — Opus 4.8 will throw if either is set.
+};
+```
+
+`Chat`/`sendChat` also accept these as optional fields (new — previously only `generateResponse` exposed them), so existing `Chat` objects that omit them are unaffected:
+
+```typescript
+let currentChat: Chat = {
+  model: "claude-opus-4-8",
+  responseHistory: [],
+  prompt: "Solve this.",
+  maxTokens: 4096,
+  visionUrl: null,
+  budgetTokens: null,
+  effort: "high", // optional — new
+  outputFormat: undefined, // optional — new, structured output via output_config.format
+};
+```
+
 ## Development
 
 - **Build:** `npm run build` (Compiles TS to `dist/`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "snowgander",
-  "version": "0.2.39",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snowgander",
-      "version": "0.2.39",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
+        "@anthropic-ai/sdk": "^0.111.0",
         "@google/genai": "^1.34.0",
         "@types/jest": "^29.5.14",
         "axios": "^1.8.4",
@@ -35,17 +35,23 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
+      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -417,6 +423,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -943,6 +957,11 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
@@ -1048,15 +1067,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1075,17 +1085,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1093,17 +1092,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1800,14 +1788,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -1863,6 +1843,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2038,23 +2023,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -2364,14 +2332,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -3178,6 +3138,18 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3394,25 +3366,6 @@
       ],
       "engines": {
         "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-int64": {
@@ -3926,6 +3879,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -4100,10 +4062,10 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/ts-jest": {
       "version": "29.3.2",
@@ -4276,28 +4238,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4430,16 +4370,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowgander",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Universal interface for disperate AI vendors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,7 +39,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@google/genai": "^1.34.0",
     "@types/jest": "^29.5.14",
     "axios": "^1.8.4",

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,11 @@ export interface Chat {
   // Options specific to OpenAI Image Adapter, passed via Chat
   openaiImageGenerationOptions?: OpenAIImageGenerationOptions;
   openaiImageEditOptions?: OpenAIImageEditOptions;
+  // Claude 4.6+ specific options (optional — omit to preserve prior behavior)
+  effort?: "low" | "medium" | "high" | "xhigh" | "max"; // Effort level for adaptive thinking
+  temperature?: number; // Sampling temperature (rejected outright on some newer models)
+  topP?: number; // Top-p sampling (alternative to temperature, only for legacy-tier models)
+  outputFormat?: any; // Structured output format for output_config
 }
 
 // Represents an MCP Tool configuration
@@ -187,9 +192,9 @@ export interface AIRequestOptions {
   // New: Specific flag to control image generation per request
   useImageGeneration?: boolean;
   // Claude 4.6+ specific options
-  effort?: "low" | "medium" | "high"; // Effort level for adaptive thinking (Claude 4.6+)
+  effort?: "low" | "medium" | "high" | "xhigh" | "max"; // Effort level for adaptive thinking (Claude 4.6+)
   outputFormat?: any; // Structured output format for output_config (Claude 4.6+)
-  topP?: number; // Top-p sampling (alternative to temperature, only for Claude 3.x)
+  topP?: number; // Top-p sampling (alternative to temperature, only for legacy-tier models)
 }
 
 // --- OpenAI Image API Specific Options ---

--- a/src/vendors/__tests__/anthropic.test.ts
+++ b/src/vendors/__tests__/anthropic.test.ts
@@ -747,6 +747,47 @@ describe("AnthropicAdapter", () => {
       );
     });
 
+    it("should forward effort, temperature, topP, and outputFormat to generateResponse", async () => {
+      const schema = { type: "object", properties: {} };
+      const chatWithExtras: Chat = {
+        ...baseChat,
+        effort: "xhigh",
+        temperature: 0.4,
+        topP: 0.8,
+        outputFormat: schema,
+        prompt: "Use the extras",
+      } as Chat;
+
+      await adapter.sendChat(chatWithExtras);
+
+      expect(generateResponseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          effort: "xhigh",
+          temperature: 0.4,
+          topP: 0.8,
+          outputFormat: schema,
+        })
+      );
+    });
+
+    it("should enable thinkingMode when effort is set even without budgetTokens", async () => {
+      const chatWithEffortOnly: Chat = {
+        ...baseChat,
+        effort: "high",
+        budgetTokens: null,
+        prompt: "Think, please",
+      } as Chat;
+
+      await adapter.sendChat(chatWithEffortOnly);
+
+      expect(generateResponseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinkingMode: true,
+          effort: "high",
+        })
+      );
+    });
+
     it("should return the ChatResponse with content and usage from generateResponse", async () => {
       const chat: Chat = baseChat as Chat;
       const expectedUsage: UsageResponse = {
@@ -849,7 +890,7 @@ describe("AnthropicAdapter", () => {
     });
   });
 
-  describe("Claude 4.6 support", () => {
+  describe("Claude 4.6+ model support", () => {
     const mockClaude46: ModelConfig = {
       apiName: "claude-opus-4-6",
       isVision: true,
@@ -859,6 +900,54 @@ describe("AnthropicAdapter", () => {
       outputTokenCost: 75 / 1_000_000,
     };
 
+    const mockSonnet46: ModelConfig = {
+      apiName: "claude-sonnet-4-6",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 3 / 1_000_000,
+      outputTokenCost: 15 / 1_000_000,
+    };
+
+    const mockOpus47: ModelConfig = {
+      apiName: "claude-opus-4-7",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 5 / 1_000_000,
+      outputTokenCost: 25 / 1_000_000,
+    };
+
+    const mockOpus48: ModelConfig = {
+      apiName: "claude-opus-4-8",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 5 / 1_000_000,
+      outputTokenCost: 25 / 1_000_000,
+    };
+
+    const mockSonnet5: ModelConfig = {
+      apiName: "claude-sonnet-5",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 3 / 1_000_000,
+      outputTokenCost: 15 / 1_000_000,
+    };
+
+    const mockFable5: ModelConfig = {
+      apiName: "claude-fable-5",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 10 / 1_000_000,
+      outputTokenCost: 50 / 1_000_000,
+    };
+
+    // claude-sonnet-4-5 and claude-haiku-4-5 do NOT support adaptive thinking or
+    // effort per Anthropic's docs, despite the "4-5"/"4.5" naming resemblance to
+    // adaptive-capable models. These fixtures cover the legacy budget_tokens path.
     const mockClaudeSonnet45: ModelConfig = {
       apiName: "claude-sonnet-4-5-20250929",
       isVision: true,
@@ -866,6 +955,15 @@ describe("AnthropicAdapter", () => {
       isThinking: true,
       inputTokenCost: 3 / 1_000_000,
       outputTokenCost: 15 / 1_000_000,
+    };
+
+    const mockHaiku45: ModelConfig = {
+      apiName: "claude-haiku-4-5-20251001",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 1 / 1_000_000,
+      outputTokenCost: 5 / 1_000_000,
     };
 
     const basicMessages: Message[] = [
@@ -1115,7 +1213,11 @@ describe("AnthropicAdapter", () => {
       }
     });
 
-    it("should support Sonnet 4.5 with adaptive thinking", async () => {
+    // Sonnet 4.5 and Haiku 4.5 use the legacy budget_tokens thinking API, NOT
+    // adaptive thinking — they do not support the effort parameter. Passing
+    // `effort` alone (no budgetTokens) has no effect for these models; the
+    // legacy budget_tokens fallback heuristic still applies.
+    it("should use legacy budget_tokens for Sonnet 4.5 (no adaptive thinking support)", async () => {
       const adapterSonnet45 = new AnthropicAdapter(
         mockConfig,
         mockClaudeSonnet45
@@ -1137,14 +1239,399 @@ describe("AnthropicAdapter", () => {
         model: mockClaudeSonnet45.apiName,
         messages: basicMessages,
         thinkingMode: true,
-        effort: "medium",
+        effort: "medium", // Ignored — this tier doesn't use output_config/effort
+      });
+
+      const call = mockMessagesCreate.mock.calls[0][0];
+      expect(call.thinking).toEqual({
+        type: "enabled",
+        budget_tokens: 512, // Math.floor((maxTokens ?? 1024) / 2) fallback
+      });
+      expect(call.output_config).toBeUndefined();
+    });
+
+    it("should use legacy budget_tokens for Haiku 4.5 (no adaptive thinking support)", async () => {
+      const adapterHaiku45 = new AnthropicAdapter(mockConfig, mockHaiku45);
+      const { mockMessagesCreate } = getMockAnthropicClient();
+
+      const mockApiResponse = {
+        id: "msg_haiku45",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hello!" }],
+        model: mockHaiku45.apiName,
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+      mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+      await adapterHaiku45.generateResponse({
+        model: mockHaiku45.apiName,
+        messages: basicMessages,
+        thinkingMode: true,
+        budgetTokens: 3000,
+      });
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "enabled", budget_tokens: 3000 },
+        })
+      );
+      const call = mockMessagesCreate.mock.calls[0][0];
+      expect(call.output_config).toBeUndefined();
+    });
+
+    it("should use adaptive thinking with effort for Sonnet 4.6 (adaptive-transitional tier)", async () => {
+      const adapterSonnet46 = new AnthropicAdapter(mockConfig, mockSonnet46);
+      const { mockMessagesCreate } = getMockAnthropicClient();
+
+      const mockApiResponse = {
+        id: "msg_sonnet46",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hello!" }],
+        model: mockSonnet46.apiName,
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+      mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+      await adapterSonnet46.generateResponse({
+        model: mockSonnet46.apiName,
+        messages: basicMessages,
+        thinkingMode: true,
+        effort: "max",
       });
 
       expect(mockMessagesCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           thinking: { type: "adaptive" },
-          output_config: { effort: "medium" },
+          output_config: { effort: "max" },
         })
+      );
+    });
+
+    it.each([
+      ["Opus 4.7", () => mockOpus47],
+      ["Opus 4.8", () => mockOpus48],
+      ["Sonnet 5", () => mockSonnet5],
+      ["Fable 5", () => mockFable5],
+    ])(
+      "should use adaptive thinking with effort for %s (adaptive-only tier)",
+      async (_label, getModel) => {
+        const model = getModel();
+        const adaptiveOnlyAdapter = new AnthropicAdapter(mockConfig, model);
+        const { mockMessagesCreate } = getMockAnthropicClient();
+
+        const mockApiResponse = {
+          id: "msg_adaptive_only",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "Hello!" }],
+          model: model.apiName,
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+        mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+        await adaptiveOnlyAdapter.generateResponse({
+          model: model.apiName,
+          messages: basicMessages,
+          thinkingMode: true,
+          effort: "xhigh",
+        });
+
+        expect(mockMessagesCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            thinking: { type: "adaptive" },
+            output_config: { effort: "xhigh" },
+          })
+        );
+      }
+    );
+
+    it.each(["xhigh", "max"] as const)(
+      "should pass explicit effort '%s' through for adaptive-only models",
+      async (effort) => {
+        const adapter48 = new AnthropicAdapter(mockConfig, mockOpus48);
+        const { mockMessagesCreate } = getMockAnthropicClient();
+
+        const mockApiResponse = {
+          id: "msg_effort_level",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "Hello!" }],
+          model: mockOpus48.apiName,
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+        mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+        await adapter48.generateResponse({
+          model: mockOpus48.apiName,
+          messages: basicMessages,
+          thinkingMode: true,
+          effort,
+        });
+
+        expect(mockMessagesCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            output_config: { effort },
+          })
+        );
+      }
+    );
+
+    it("should never send budget_tokens for adaptive-only models, even when budgetTokens is provided", async () => {
+      const adapter48 = new AnthropicAdapter(mockConfig, mockOpus48);
+      const { mockMessagesCreate } = getMockAnthropicClient();
+
+      const mockApiResponse = {
+        id: "msg_no_budget",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hello!" }],
+        model: mockOpus48.apiName,
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+      mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+      await adapter48.generateResponse({
+        model: mockOpus48.apiName,
+        messages: basicMessages,
+        thinkingMode: true,
+        budgetTokens: 20000, // Only used for the effort heuristic — never sent raw.
+      });
+
+      const call = mockMessagesCreate.mock.calls[0][0];
+      expect(call.thinking).toEqual({ type: "adaptive" });
+      expect(call.output_config).toEqual({ effort: "high" });
+      expect(call.thinking.budget_tokens).toBeUndefined();
+    });
+
+    it("should throw when temperature alone is provided for adaptive-only models", async () => {
+      const adapter48 = new AnthropicAdapter(mockConfig, mockOpus48);
+
+      await expect(
+        adapter48.generateResponse({
+          model: mockOpus48.apiName,
+          messages: basicMessages,
+          temperature: 0.5,
+        })
+      ).rejects.toThrow(/does not support sampling parameters/);
+    });
+
+    it("should throw when topP alone is provided for adaptive-only models", async () => {
+      const adapter48 = new AnthropicAdapter(mockConfig, mockOpus48);
+
+      await expect(
+        adapter48.generateResponse({
+          model: mockOpus48.apiName,
+          messages: basicMessages,
+          topP: 0.9,
+        })
+      ).rejects.toThrow(/does not support sampling parameters/);
+    });
+
+    it("should throw when both temperature and topP are provided for adaptive-only models", async () => {
+      const adapterFable5 = new AnthropicAdapter(mockConfig, mockFable5);
+
+      await expect(
+        adapterFable5.generateResponse({
+          model: mockFable5.apiName,
+          messages: basicMessages,
+          temperature: 0.5,
+          topP: 0.9,
+        })
+      ).rejects.toThrow(/does not support sampling parameters/);
+    });
+
+    it("should throw when both temperature and topP are provided for Sonnet 4.6", async () => {
+      const adapterSonnet46 = new AnthropicAdapter(mockConfig, mockSonnet46);
+
+      await expect(
+        adapterSonnet46.generateResponse({
+          model: mockSonnet46.apiName,
+          messages: basicMessages,
+          temperature: 0.5,
+          topP: 0.9,
+        })
+      ).rejects.toThrow(/do not support using both temperature and top_p/);
+    });
+
+    it("should allow topP alone for Sonnet 4.6 (single sampling param permitted)", async () => {
+      const adapterSonnet46 = new AnthropicAdapter(mockConfig, mockSonnet46);
+      const { mockMessagesCreate } = getMockAnthropicClient();
+
+      const mockApiResponse = {
+        id: "msg_sonnet46_topp",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Hello!" }],
+        model: mockSonnet46.apiName,
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+      mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+      await adapterSonnet46.generateResponse({
+        model: mockSonnet46.apiName,
+        messages: basicMessages,
+        topP: 0.9,
+      });
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ top_p: 0.9 })
+      );
+      const call = mockMessagesCreate.mock.calls[0][0];
+      expect(call.temperature).toBeUndefined();
+    });
+
+    it("should include stop_details.category in the refusal error block when present", async () => {
+      const { mockMessagesCreate } = getMockAnthropicClient();
+
+      const mockApiResponse = {
+        id: "msg_refuse_category",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: mockFable5.apiName,
+        stop_reason: "refusal" as any,
+        stop_details: { type: "refusal", category: "cyber", explanation: null },
+        usage: { input_tokens: 10, output_tokens: 0 },
+      };
+      mockMessagesCreate.mockResolvedValue(mockApiResponse);
+
+      const adapterFable5 = new AnthropicAdapter(mockConfig, mockFable5);
+      const response = await adapterFable5.generateResponse({
+        model: mockFable5.apiName,
+        messages: basicMessages,
+      });
+
+      expect(response.content).toContainEqual(
+        expect.objectContaining({
+          type: "error",
+          privateMessage: expect.stringContaining("cyber"),
+        })
+      );
+    });
+
+    describe("model tier classification", () => {
+      // Exercises the private tier-classification helpers directly against the
+      // full capability table, since many models share identical downstream
+      // request-building behavior and don't each need a full generateResponse
+      // round trip to prove correct bucketing.
+      const getTiers = (model: string) => {
+        const anyAdapter = adapter as any;
+        return {
+          thinkingTier: anyAdapter.getThinkingTier(model),
+          samplingPolicy: anyAdapter.getSamplingPolicy(model),
+        };
+      };
+
+      it.each([
+        ["claude-3-opus-20240229", "legacyBudget", "both"],
+        ["claude-3-5-sonnet-20241022", "legacyBudget", "both"],
+        ["claude-opus-4-5-20251101", "legacyBudget", "single"],
+        ["claude-opus-4-1-20250805", "legacyBudget", "single"],
+        ["claude-opus-4-20250514", "legacyBudget", "single"],
+        ["claude-sonnet-4-5-20250929", "legacyBudget", "single"],
+        ["claude-sonnet-4-20250514", "legacyBudget", "single"],
+        ["claude-haiku-4-5-20251001", "legacyBudget", "single"],
+        ["claude-opus-4-6", "adaptiveTransitional", "single"],
+        ["claude-sonnet-4-6", "adaptiveTransitional", "single"],
+        ["claude-opus-4-7", "adaptiveOnly", "none"],
+        ["claude-opus-4-8", "adaptiveOnly", "none"],
+        ["claude-sonnet-5", "adaptiveOnly", "none"],
+        ["claude-fable-5", "adaptiveOnly", "none"],
+        ["claude-mythos-5", "adaptiveOnly", "none"],
+        ["some-unknown-future-model", "legacyBudget", "single"],
+      ])(
+        "classifies %s as thinking tier '%s' and sampling policy '%s'",
+        (model, expectedTier, expectedPolicy) => {
+          const { thinkingTier, samplingPolicy } = getTiers(model);
+          expect(thinkingTier).toBe(expectedTier);
+          expect(samplingPolicy).toBe(expectedPolicy);
+        }
+      );
+    });
+  });
+
+  describe("streamResponse: Claude 4.6+ model support", () => {
+    const mockOpus48: ModelConfig = {
+      apiName: "claude-opus-4-8",
+      isVision: true,
+      isImageGeneration: false,
+      isThinking: true,
+      inputTokenCost: 5 / 1_000_000,
+      outputTokenCost: 25 / 1_000_000,
+    };
+
+    const basicMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello stream!" }] },
+    ];
+
+    it("should use adaptive thinking with effort when streaming an adaptive-only model", async () => {
+      const adapter48 = new AnthropicAdapter(mockConfig, mockOpus48);
+      const { mockMessagesCreate } = getMockAnthropicClient();
+
+      async function* mockStream() {
+        yield {
+          type: "message_start",
+          message: { id: "msg_stream_48", usage: { input_tokens: 10 } },
+        };
+        yield {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        };
+        yield {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "Hi!" },
+        };
+        yield { type: "content_block_stop", index: 0 };
+        yield {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { output_tokens: 3 },
+        };
+        yield { type: "message_stop" };
+      }
+      mockMessagesCreate.mockResolvedValue(mockStream());
+
+      const stream = adapter48.streamResponse({
+        model: mockOpus48.apiName,
+        messages: basicMessages,
+        thinkingMode: true,
+        effort: "high",
+      });
+      const chunks: ContentBlock[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "high" },
+        })
+      );
+      expect(chunks[0]).toEqual({ type: "text", text: "Hi!" });
+    });
+
+    it("should reject sampling parameters when streaming an adaptive-only model", async () => {
+      const adapter48 = new AnthropicAdapter(mockConfig, mockOpus48);
+
+      const stream = adapter48.streamResponse({
+        model: mockOpus48.apiName,
+        messages: basicMessages,
+        temperature: 0.5,
+      });
+
+      await expect(stream.next()).rejects.toThrow(
+        /does not support sampling parameters/
       );
     });
   });

--- a/src/vendors/anthropic.ts
+++ b/src/vendors/anthropic.ts
@@ -9,6 +9,7 @@ import {
   ChatResponse,
   ContentBlock,
   ToolUseBlock,
+  Message,
   // MCPTool, // MCPTool type might not be needed if sendMCPChat is removed/integrated
   UsageResponse,
   ImageBlock,
@@ -24,6 +25,44 @@ import {
 } from "@anthropic-ai/sdk/resources/messages";
 // Removed Prisma Model import
 // Removed application-specific imports (updateUserUsage, getCurrentAPIUser)
+
+// --- Model capability tiers ---
+//
+// Anthropic's request shape for thinking/effort/sampling parameters differs across
+// model generations. These two independent classifications drive that behavior:
+//
+// - Thinking tier: which thinking API a model speaks (legacy budget_tokens vs
+//   adaptive), and which effort levels are meaningful.
+// - Sampling policy: how many of temperature/top_p a model accepts. This is NOT
+//   1:1 with the thinking tier — e.g. Sonnet 4.5 and Haiku 4.5 use legacy
+//   budget_tokens thinking, but like every Claude 4+ model they reject sending
+//   both temperature and top_p together.
+type ThinkingTier = "legacyBudget" | "adaptiveTransitional" | "adaptiveOnly";
+type SamplingPolicy = "both" | "single" | "none";
+
+// Anthropic content-block param shapes used when formatting our messages for the
+// request. Kept local to this file since these are request-only shapes.
+type FormattedAnthropicContentBlock =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "thinking";
+      thinking: string;
+      signature: string;
+    }
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: string | Array<{ type: "text"; text: string }>;
+    }
+  | ToolUseBlockParam; // Add Anthropic's ToolUseBlockParam type
+
+type FormattedAnthropicMessage = {
+  role: "user" | "assistant";
+  content: string | FormattedAnthropicContentBlock[];
+};
 
 export class AnthropicAdapter implements AIVendorAdapter {
   private client: Anthropic;
@@ -52,41 +91,297 @@ export class AnthropicAdapter implements AIVendorAdapter {
   }
 
   /**
-   * Detect Claude model generation from model name
-   * @param modelName - The model identifier (e.g., "claude-opus-4-6")
-   * @returns Model generation category
+   * Classify a model into a thinking-capability tier. Checks are ordered
+   * most-specific-first so newer model families aren't accidentally caught by a
+   * broader/older pattern (e.g. "claude-opus-4-8" must be checked before a bare
+   * "claude-opus-4" fallback would ever be considered).
+   *
+   * Unknown/future model strings fall back to "legacyBudget" — the behavior every
+   * Claude model has supported since thinking was introduced, and the safest
+   * default until this table is updated for a new release.
+   *
+   * @param modelName - The model identifier (e.g., "claude-opus-4-8")
    */
-  private getModelGeneration(modelName: string): "3.x" | "4.0-4.5" | "4.6+" {
-    // Claude 4.6+ patterns (Opus 4.6, Sonnet 4.5, Haiku 4.5)
+  private getThinkingTier(modelName: string): ThinkingTier {
+    // Adaptive-only: thinking is always adaptive, budget_tokens is rejected (400),
+    // and effort supports the full low/medium/high/xhigh/max range.
+    if (
+      modelName.includes("claude-opus-4-7") ||
+      modelName.includes("claude-opus-4-8") ||
+      modelName.includes("claude-sonnet-5") ||
+      modelName.includes("claude-fable-5") ||
+      modelName.includes("claude-mythos-5")
+    ) {
+      return "adaptiveOnly";
+    }
+
+    // Adaptive-transitional: adaptive thinking is supported and recommended;
+    // effort supports low/medium/high/max (no xhigh).
     if (
       modelName.includes("claude-opus-4-6") ||
-      modelName.includes("claude-sonnet-4-5") ||
-      modelName.includes("claude-haiku-4-5")
+      modelName.includes("claude-sonnet-4-6")
     ) {
-      return "4.6+";
+      return "adaptiveTransitional";
     }
 
-    // Claude 4.0-4.5 patterns
-    if (
-      modelName.includes("claude-opus-4") ||
-      modelName.includes("claude-sonnet-4")
-    ) {
-      return "4.0-4.5";
-    }
-
-    // Claude 3.x (default for older/unknown models)
-    return "3.x";
+    // Legacy: Claude 3.x, Opus 4.0/4.1/4.5, Sonnet 4.0/4.5, Haiku 3.x/4.5, and any
+    // unrecognized/future model string. Thinking (if supported) uses
+    // {type: "enabled", budget_tokens}; no output_config/effort support.
+    return "legacyBudget";
   }
 
   /**
-   * Map budgetTokens to effort level for Claude 4.6+ adaptive thinking
-   * @param budgetTokens - Token budget for thinking
+   * Classify a model's sampling-parameter (temperature/top_p) constraints.
+   * Independent from the thinking tier — see the type comment above.
+   *
+   * @param modelName - The model identifier (e.g., "claude-opus-4-8")
+   */
+  private getSamplingPolicy(modelName: string): SamplingPolicy {
+    // No Claude 4+ model accepts sampling parameters once it's adaptive-only.
+    if (this.getThinkingTier(modelName) === "adaptiveOnly") {
+      return "none";
+    }
+
+    // Claude 2.x / 3.x models accept temperature and top_p together.
+    if (modelName.includes("claude-3") || modelName.includes("claude-2")) {
+      return "both";
+    }
+
+    // Every other Claude 4.x-family model (4.0/4.1/4.5, the 4.6 family, Sonnet
+    // 4.5, Haiku 4.5, etc.) accepts at most one sampling parameter.
+    return "single";
+  }
+
+  /**
+   * Map budgetTokens to an effort level for adaptive-thinking tiers, used only
+   * when the caller hasn't provided an explicit `effort`. This heuristic only
+   * reaches low/medium/high — "xhigh" and "max" are only reachable via an
+   * explicit `effort` value, since there's no principled budget-token threshold
+   * to derive them from.
+   * @param budgetTokens - Token budget for thinking mode
    * @returns Effort level (low/medium/high)
    */
   private mapBudgetToEffort(budgetTokens?: number): "low" | "medium" | "high" {
     if (!budgetTokens || budgetTokens === 0) return "low";
     if (budgetTokens < 8192) return "medium";
     return "high";
+  }
+
+  /**
+   * Validates temperature/top_p against the model's sampling policy and returns
+   * the fragment to merge into the request params. Throws a descriptive error
+   * when the combination is invalid for this model, rather than letting an
+   * incompatible request reach the API as an opaque 400.
+   */
+  private buildSamplingParams(
+    model: string,
+    temperature: number | undefined,
+    topP: number | undefined
+  ): { temperature?: number; top_p?: number } {
+    const policy = this.getSamplingPolicy(model);
+
+    if (policy === "none") {
+      if (temperature !== undefined || topP !== undefined) {
+        throw new Error(
+          `Model '${model}' does not support sampling parameters (temperature, top_p). ` +
+            `Remove these parameters when using this model.`
+        );
+      }
+      return {};
+    }
+
+    if (policy === "single" && temperature !== undefined && topP !== undefined) {
+      throw new Error(
+        `Models like '${model}' do not support using both temperature and top_p. ` +
+          `Please provide only one sampling parameter.`
+      );
+    }
+
+    const params: { temperature?: number; top_p?: number } = {};
+    if (temperature !== undefined) {
+      params.temperature = temperature;
+    }
+    if (topP !== undefined) {
+      params.top_p = topP;
+    }
+    return params;
+  }
+
+  /**
+   * Builds the `thinking` / `output_config` request fragment for a given tier.
+   * Shared between generateResponse and streamResponse.
+   */
+  private buildThinkingParams(
+    tier: ThinkingTier,
+    thinkingMode: boolean | undefined,
+    budgetTokens: number | undefined,
+    maxTokens: number | undefined,
+    effort: AIRequestOptions["effort"],
+    outputFormat: any
+  ): { thinking?: any; output_config?: any } {
+    const result: { thinking?: any; output_config?: any } = {};
+
+    if (thinkingMode && this.isThinkingCapable) {
+      if (tier === "legacyBudget") {
+        // Use legacy budget_tokens for models without adaptive thinking support.
+        result.thinking = {
+          type: "enabled",
+          budget_tokens: budgetTokens || Math.floor((maxTokens || 1024) / 2),
+        };
+      } else {
+        // Use adaptive thinking for adaptiveTransitional/adaptiveOnly tiers.
+        result.thinking = { type: "adaptive" };
+
+        // Map budgetTokens to effort if provided, or use explicit effort parameter
+        if (budgetTokens !== undefined || effort) {
+          result.output_config = {
+            effort: effort || this.mapBudgetToEffort(budgetTokens),
+          };
+        }
+      }
+    }
+
+    // Structured output support is available on adaptive-capable tiers.
+    if (outputFormat && tier !== "legacyBudget") {
+      result.output_config = {
+        ...result.output_config,
+        format: outputFormat,
+      };
+    }
+
+    return result;
+  }
+
+  /**
+   * Converts our Message[]/ContentBlock[] format into Anthropic's request
+   * message shape. Shared between generateResponse and streamResponse so the
+   * two methods can't drift out of sync with each other.
+   */
+  private formatMessages(
+    messages: Message[],
+    model: string
+  ): FormattedAnthropicMessage[] {
+    return messages.map((msg) => {
+      const role =
+        msg.role === "assistant" ? ("assistant" as const) : ("user" as const);
+
+      if (typeof msg.content === "string") {
+        return { role, content: msg.content };
+      }
+
+      // Map our content blocks to Anthropic's ContentBlockParam format
+      const mappedContent = msg.content.reduce<FormattedAnthropicContentBlock[]>(
+        (acc, block) => {
+          if (block.type === "text") {
+            acc.push({
+              type: "text",
+              text: block.text,
+            });
+          } else if (block.type === "thinking") {
+            // Map thinking block - Although Anthropic doesn't accept these in requests,
+            // the test expects the formatting logic to handle them.
+            acc.push({
+              type: "thinking",
+              thinking: block.thinking,
+              signature: block.signature, // Assuming signature maps directly, adjust if needed
+            });
+          } else if (block.type === "tool_result" && msg.role === "user") {
+            // Handle tool_result specifically for user messages
+            // Anthropic expects tool_result content to be a string or an array of text blocks.
+            // We'll convert our ContentBlock[] to a simple string for now.
+            // TODO: Improve this to handle potential multiple text blocks in tool_result.content if needed.
+            const toolResultContent = block.content
+              .map((c) => (c.type === "text" ? c.text : JSON.stringify(c)))
+              .join("\n");
+
+            acc.push({
+              type: "tool_result",
+              tool_use_id: block.toolUseId, // Use the string ID directly
+              content: toolResultContent, // Send as string for simplicity
+              // Alternatively, format as [{ type: 'text', text: toolResultContent }] if preferred
+            });
+          } else if (block.type === "tool_use" && msg.role === "assistant") {
+            // Map tool_use blocks from assistant history correctly for the API request
+            // Ensure the ID exists and input is valid JSON
+            if (block.id && typeof block.input === "string") {
+              try {
+                const parsedInput = JSON.parse(block.input);
+                acc.push({
+                  type: "tool_use",
+                  id: block.id,
+                  name: block.name,
+                  input: parsedInput, // Anthropic expects the parsed object here
+                });
+              } catch (e) {
+                console.error(
+                  `Skipping tool_use block due to invalid JSON input: ${block.input}`,
+                  e
+                );
+              }
+            } else {
+              console.warn(
+                "Skipping tool_use block due to missing ID or invalid input type."
+              );
+            }
+          } else if (
+            block.type === "image" &&
+            this.isVisionCapable &&
+            msg.role === "user"
+          ) {
+            // Handle ImageBlock (URL) for vision-capable models in user messages
+            // Map to Anthropic's expected format based on their documentation example
+            acc.push({
+              type: "image",
+              source: {
+                type: "url",
+                // Ensure 'url' property exists on our ImageBlock type
+                url: block.url,
+              },
+            } as any); // Use 'as any' for now if the SDK type doesn't perfectly align or needs broader compatibility
+          } else if (
+            block.type === "image_data" &&
+            this.isVisionCapable &&
+            msg.role === "user"
+          ) {
+            // Handle ImageDataBlock (base64) - Anthropic example only shows URL source.
+            // Warn the developer, as this might not be directly supported or requires different formatting.
+            console.warn(
+              "Anthropic adapter received ImageDataBlock (base64). Anthropic API example uses URL source. Skipping image. Check Anthropic documentation for base64 support."
+            );
+            // If Anthropic *did* support base64 via a specific format (e.g., type: 'base64'), the mapping would go here.
+            // Example (hypothetical, verify with docs):
+            // acc.push({
+            //   type: "image",
+            //   source: {
+            //     type: "base64",
+            //     media_type: block.mimeType,
+            //     data: block.base64Data,
+            //   }
+            // } as any);
+          } else if (
+            (block.type === "image" || block.type === "image_data") &&
+            (!this.isVisionCapable || msg.role !== "user")
+          ) {
+            // Skip images if model isn't vision capable or if not in a user message
+            console.warn(
+              `Skipping image block (type: ${block.type}) in role '${msg.role}' for model '${model}'. Vision capable: ${this.isVisionCapable}`
+            );
+          }
+          // Note: Image blocks are now handled above.
+          return acc;
+        },
+        []
+      );
+
+      // If we have no valid content blocks, convert to a text block with the stringified content
+      return {
+        role,
+        content:
+          mappedContent.length > 0
+            ? mappedContent
+            : JSON.stringify(msg.content),
+      };
+    });
   }
 
   async generateResponse(options: AIRequestOptions): Promise<AIResponse> {
@@ -105,203 +400,35 @@ export class AnthropicAdapter implements AIVendorAdapter {
       topP,
     } = options;
 
-    // Validate sampling parameters (breaking change for Claude 4+)
-    if (temperature !== undefined && topP !== undefined) {
-      const modelGen = this.getModelGeneration(model);
-      if (modelGen !== "3.x") {
-        throw new Error(
-          `Claude ${modelGen} models do not support using both temperature and top_p. ` +
-            `Please provide only one sampling parameter.`
-        );
-      }
-    }
+    // Validate sampling parameters (throws a descriptive error for
+    // incompatible model/parameter combinations rather than an opaque 400)
+    const samplingParams = this.buildSamplingParams(model, temperature, topP);
 
-    // Determine model generation for version-aware features
-    const modelGen = this.getModelGeneration(model);
+    // Determine model tier for version-aware features
+    const tier = this.getThinkingTier(model);
 
     // Convert messages to Anthropic format
-    // Convert messages to Anthropic format with inferred types
-    const formattedMessages = messages.map((msg) => {
-      const role =
-        msg.role === "assistant" ? ("assistant" as const) : ("user" as const);
+    const formattedMessages = this.formatMessages(messages, model);
 
-      if (typeof msg.content === "string") {
-        return { role, content: msg.content };
-      }
+    // Build thinking / output_config request fragment
+    const thinkingParams = this.buildThinkingParams(
+      tier,
+      thinkingMode,
+      budgetTokens,
+      maxTokens,
+      effort,
+      outputFormat
+    );
 
-      // Map our content blocks to Anthropic's ContentBlockParam format
-      const mappedContent = msg.content.reduce<
-        Array<
-          | {
-              type: "text";
-              text: string;
-            }
-          | {
-              type: "thinking";
-              thinking: string;
-              signature: string;
-            }
-          | {
-              type: "tool_result";
-              tool_use_id: string;
-              content: string | Array<{ type: "text"; text: string }>;
-            }
-          | ToolUseBlockParam // Add Anthropic's ToolUseBlockParam type
-        >
-      >((acc, block) => {
-        if (block.type === "text") {
-          acc.push({
-            type: "text",
-            text: block.text,
-          });
-        } else if (block.type === "thinking") {
-          // Map thinking block - Although Anthropic doesn't accept these in requests,
-          // the test expects the formatting logic to handle them.
-          acc.push({
-            type: "thinking",
-            thinking: block.thinking,
-            signature: block.signature, // Assuming signature maps directly, adjust if needed
-          });
-        } else if (block.type === "tool_result" && msg.role === "user") {
-          // Handle tool_result specifically for user messages
-          // Anthropic expects tool_result content to be a string or an array of text blocks.
-          // We'll convert our ContentBlock[] to a simple string for now.
-          // TODO: Improve this to handle potential multiple text blocks in tool_result.content if needed.
-          const toolResultContent = block.content
-            .map((c) => (c.type === "text" ? c.text : JSON.stringify(c)))
-            .join("\n");
-
-          acc.push({
-            type: "tool_result",
-            tool_use_id: block.toolUseId, // Use the string ID directly
-            content: toolResultContent, // Send as string for simplicity
-            // Alternatively, format as [{ type: 'text', text: toolResultContent }] if preferred
-          });
-        } else if (block.type === "tool_use" && msg.role === "assistant") {
-          // Map tool_use blocks from assistant history correctly for the API request
-          // Ensure the ID exists and input is valid JSON
-          if (block.id && typeof block.input === "string") {
-            try {
-              const parsedInput = JSON.parse(block.input);
-              acc.push({
-                type: "tool_use",
-                id: block.id,
-                name: block.name,
-                input: parsedInput, // Anthropic expects the parsed object here
-              });
-            } catch (e) {
-              console.error(
-                `Skipping tool_use block due to invalid JSON input: ${block.input}`,
-                e
-              );
-            }
-          } else {
-            console.warn(
-              "Skipping tool_use block due to missing ID or invalid input type."
-            );
-          }
-        } else if (
-          block.type === "image" &&
-          this.isVisionCapable &&
-          msg.role === "user"
-        ) {
-          // Handle ImageBlock (URL) for vision-capable models in user messages
-          // Map to Anthropic's expected format based on their documentation example
-          acc.push({
-            type: "image",
-            source: {
-              type: "url",
-              // Ensure 'url' property exists on our ImageBlock type
-              url: block.url,
-            },
-          } as any); // Use 'as any' for now if the SDK type doesn't perfectly align or needs broader compatibility
-        } else if (
-          block.type === "image_data" &&
-          this.isVisionCapable &&
-          msg.role === "user"
-        ) {
-          // Handle ImageDataBlock (base64) - Anthropic example only shows URL source.
-          // Warn the developer, as this might not be directly supported or requires different formatting.
-          console.warn(
-            "Anthropic adapter received ImageDataBlock (base64). Anthropic API example uses URL source. Skipping image. Check Anthropic documentation for base64 support."
-          );
-          // If Anthropic *did* support base64 via a specific format (e.g., type: 'base64'), the mapping would go here.
-          // Example (hypothetical, verify with docs):
-          // acc.push({
-          //   type: "image",
-          //   source: {
-          //     type: "base64",
-          //     media_type: block.mimeType,
-          //     data: block.base64Data,
-          //   }
-          // } as any);
-        } else if (
-          (block.type === "image" || block.type === "image_data") &&
-          (!this.isVisionCapable || msg.role !== "user")
-        ) {
-          // Skip images if model isn't vision capable or if not in a user message
-          console.warn(
-            `Skipping image block (type: ${block.type}) in role '${msg.role}' for model '${model}'. Vision capable: ${this.isVisionCapable}`
-          );
-        }
-        // Note: Image blocks are now handled above.
-        return acc;
-      }, []);
-
-      // If we have no valid content blocks, convert to a text block with the stringified content
-      return {
-        role,
-        content:
-          mappedContent.length > 0
-            ? mappedContent
-            : JSON.stringify(msg.content),
-      };
-    });
-
-    // Build request parameters based on model generation
+    // Build request parameters based on model tier
     const requestParams: any = {
       model,
       messages: formattedMessages,
       system: systemPrompt,
       max_tokens: maxTokens || 1024,
+      ...samplingParams,
+      ...thinkingParams,
     };
-
-    // Handle thinking mode based on model generation
-    if (thinkingMode && this.isThinkingCapable) {
-      if (modelGen === "4.6+") {
-        // Use adaptive thinking for Claude 4.6+
-        requestParams.thinking = { type: "adaptive" };
-
-        // Map budgetTokens to effort if provided, or use explicit effort parameter
-        if (budgetTokens !== undefined || effort) {
-          requestParams.output_config = {
-            effort: effort || this.mapBudgetToEffort(budgetTokens),
-          };
-        }
-      } else {
-        // Use legacy budget_tokens for Claude 3.x and 4.0-4.5 models
-        requestParams.thinking = {
-          type: "enabled",
-          budget_tokens: budgetTokens || Math.floor((maxTokens || 1024) / 2),
-        };
-      }
-    }
-
-    // Add structured output support for Claude 4.6+
-    if (outputFormat && modelGen === "4.6+") {
-      requestParams.output_config = {
-        ...requestParams.output_config,
-        format: outputFormat,
-      };
-    }
-
-    // Add sampling parameters
-    if (temperature !== undefined) {
-      requestParams.temperature = temperature;
-    }
-    if (topP !== undefined && modelGen === "3.x") {
-      requestParams.top_p = topP;
-    }
 
     // Add tools if provided
     if (tools) {
@@ -361,14 +488,20 @@ export class AnthropicAdapter implements AIVendorAdapter {
     }
 
     // Handle new stop reasons (Claude 4.5+)
-    // Note: SDK types may not include these yet, so we check as strings
     const stopReason = response.stop_reason as string;
     if (stopReason === "refusal") {
-      console.warn("Model refused to respond to this request");
+      const category = response.stop_details?.category;
+      console.warn(
+        `Model refused to respond to this request${
+          category ? ` (category: ${category})` : ""
+        }`
+      );
       contentBlocks.push({
         type: "error",
         publicMessage: "The model declined to respond to this request.",
-        privateMessage: `Stop reason: ${stopReason}`,
+        privateMessage: `Stop reason: ${stopReason}${
+          category ? `, category: ${category}` : ""
+        }`,
       });
     }
 
@@ -419,128 +552,18 @@ export class AnthropicAdapter implements AIVendorAdapter {
       topP,
     } = options;
 
-    // Validate sampling parameters (breaking change for Claude 4+)
-    if (temperature !== undefined && topP !== undefined) {
-      const modelGen = this.getModelGeneration(model);
-      if (modelGen !== "3.x") {
-        throw new Error(
-          `Claude ${modelGen} models do not support using both temperature and top_p. ` +
-            `Please provide only one sampling parameter.`
-        );
-      }
-    }
+    // Validate sampling parameters (throws a descriptive error for
+    // incompatible model/parameter combinations rather than an opaque 400)
+    const samplingParams = this.buildSamplingParams(model, temperature, topP);
 
-    // Determine model generation for version-aware features
-    const modelGen = this.getModelGeneration(model);
+    // Determine model tier for version-aware features
+    const tier = this.getThinkingTier(model);
 
-    // This message formatting logic is copied from generateResponse and is correct.
-    const formattedMessages = messages.map((msg) => {
-      const role =
-        msg.role === "assistant" ? ("assistant" as const) : ("user" as const);
-      if (typeof msg.content === "string") {
-        return { role, content: msg.content };
-      }
-      const mappedContent = msg.content.reduce<
-        Array<
-          | {
-              type: "text";
-              text: string;
-            }
-          | {
-              type: "thinking";
-              thinking: string;
-              signature: string;
-            }
-          | {
-              type: "tool_result";
-              tool_use_id: string;
-              content: string | Array<{ type: "text"; text: string }>;
-            }
-          | ToolUseBlockParam
-        >
-      >((acc, block) => {
-        if (block.type === "text") {
-          acc.push({
-            type: "text",
-            text: block.text,
-          });
-        } else if (block.type === "thinking") {
-          acc.push({
-            type: "thinking",
-            thinking: block.thinking,
-            signature: block.signature,
-          });
-        } else if (block.type === "tool_result" && msg.role === "user") {
-          const toolResultContent = block.content
-            .map((c) => (c.type === "text" ? c.text : JSON.stringify(c)))
-            .join("\n");
-          acc.push({
-            type: "tool_result",
-            tool_use_id: block.toolUseId,
-            content: toolResultContent,
-          });
-        } else if (block.type === "tool_use" && msg.role === "assistant") {
-          if (block.id && typeof block.input === "string") {
-            try {
-              const parsedInput = JSON.parse(block.input);
-              acc.push({
-                type: "tool_use",
-                id: block.id,
-                name: block.name,
-                input: parsedInput,
-              });
-            } catch (e) {
-              console.error(
-                `Skipping tool_use block due to invalid JSON input: ${block.input}`,
-                e
-              );
-            }
-          } else {
-            console.warn(
-              "Skipping tool_use block due to missing ID or invalid input type."
-            );
-          }
-        } else if (
-          block.type === "image" &&
-          this.isVisionCapable &&
-          msg.role === "user"
-        ) {
-          acc.push({
-            type: "image",
-            source: {
-              type: "url",
-              url: block.url,
-            },
-          } as any);
-        } else if (
-          block.type === "image_data" &&
-          this.isVisionCapable &&
-          msg.role === "user"
-        ) {
-          console.warn(
-            "Anthropic adapter received ImageDataBlock (base64). Anthropic API example uses URL source. Skipping image. Check Anthropic documentation for base64 support."
-          );
-        } else if (
-          (block.type === "image" || block.type === "image_data") &&
-          (!this.isVisionCapable || msg.role !== "user")
-        ) {
-          console.warn(
-            `Skipping image block (type: ${block.type}) in role '${msg.role}' for model '${model}'. Vision capable: ${this.isVisionCapable}`
-          );
-        }
-        return acc;
-      }, []);
-      return {
-        role,
-        content:
-          mappedContent.length > 0
-            ? mappedContent
-            : JSON.stringify(msg.content),
-      };
-    });
+    // This message formatting logic is shared with generateResponse.
+    const formattedMessages = this.formatMessages(messages, model);
 
     try {
-      // Build stream request parameters based on model generation
+      // Build stream request parameters based on model tier
       const baseStreamParams = {
         model,
         messages: formattedMessages,
@@ -549,58 +572,18 @@ export class AnthropicAdapter implements AIVendorAdapter {
         stream: true as const, // Use 'as const' to ensure TypeScript knows this is always true
       };
 
-      // Build additional parameters
-      let thinkingParam = {};
-      let outputConfigParam = {};
-      let samplingParams = {};
-
-      // Handle thinking mode based on model generation
-      if (thinkingMode && this.isThinkingCapable) {
-        if (modelGen === "4.6+") {
-          // Use adaptive thinking for Claude 4.6+
-          thinkingParam = { thinking: { type: "adaptive" as const } };
-
-          // Map budgetTokens to effort if provided, or use explicit effort parameter
-          if (budgetTokens !== undefined || effort) {
-            outputConfigParam = {
-              output_config: {
-                effort: effort || this.mapBudgetToEffort(budgetTokens),
-              },
-            };
-          }
-        } else {
-          // Use legacy budget_tokens for Claude 3.x and 4.0-4.5 models
-          thinkingParam = {
-            thinking: {
-              type: "enabled" as const,
-              budget_tokens: budgetTokens || Math.floor((maxTokens || 1024) / 2),
-            },
-          };
-        }
-      }
-
-      // Add structured output support for Claude 4.6+
-      if (outputFormat && modelGen === "4.6+") {
-        outputConfigParam = {
-          output_config: {
-            ...(outputConfigParam as any).output_config,
-            format: outputFormat,
-          },
-        };
-      }
-
-      // Add sampling parameters
-      if (temperature !== undefined) {
-        samplingParams = { ...samplingParams, temperature };
-      }
-      if (topP !== undefined && modelGen === "3.x") {
-        samplingParams = { ...samplingParams, top_p: topP };
-      }
+      const thinkingParams = this.buildThinkingParams(
+        tier,
+        thinkingMode,
+        budgetTokens,
+        maxTokens,
+        effort,
+        outputFormat
+      );
 
       const stream = await this.client.messages.create({
         ...baseStreamParams,
-        ...thinkingParam,
-        ...outputConfigParam,
+        ...thinkingParams,
         ...samplingParams,
         ...(tools && { tools }),
       });
@@ -856,8 +839,15 @@ export class AnthropicAdapter implements AIVendorAdapter {
       maxTokens: chat.maxTokens || undefined,
       budgetTokens: chat.budgetTokens || undefined,
       systemPrompt: chat.systemPrompt || undefined,
-      thinkingMode: (chat.budgetTokens ?? 0) > 0,
+      // Thinking is enabled if a budget was given OR an explicit effort was
+      // requested (adaptive-tier callers may want thinking on without setting
+      // a budgetTokens value at all).
+      thinkingMode: (chat.budgetTokens ?? 0) > 0 || !!chat.effort,
       tools: formattedTools, // Pass formatted tools
+      effort: chat.effort,
+      temperature: chat.temperature,
+      topP: chat.topP,
+      outputFormat: chat.outputFormat,
     });
 
     return {

--- a/src/vendors/openai-image.ts
+++ b/src/vendors/openai-image.ts
@@ -1,5 +1,5 @@
 import OpenAI, { toFile } from "openai"; // Import toFile
-import fetch from "node-fetch"; // Need fetch for handling URL images
+// Uses Node's built-in global fetch (stable since Node 18) for handling URL images
 import { Buffer } from "buffer"; // Need Buffer for base64 decoding
 import {
   AIVendorAdapter,


### PR DESCRIPTION
…hos 5

Bump v0.4.0.

Replaces the single model-generation string with two independent capability tiers (thinking API vs sampling-parameter policy), since they don't change in lockstep across Claude releases. Adds support for Opus 4.6/4.7/4.8, Sonnet 4.6/5, Fable 5, and Mythos 5, and fixes two pre-existing bugs: Sonnet 4.5/Haiku 4.5 were incorrectly routed to adaptive thinking (would 400 against the real API), and top_p was silently dropped when passed alone on non-3.x models.

Bumps @anthropic-ai/sdk 0.39.0 -> 0.111.0 for proper typing of adaptive thinking, output_config, and refusal stop details.

Chat/sendChat now optionally forward effort/temperature/topP/ outputFormat (previously silently dropped). Behavior change: Opus 4.7/4.8, Sonnet 5, and Fable 5/Mythos 5 now throw if temperature or topP is set at all (previously only both-together threw).

Also fixes an unrelated pre-existing build break in openai-image.ts (unresolvable node-fetch import; switched to Node's built-in fetch).